### PR TITLE
Add support for an attachments

### DIFF
--- a/classes/local_contact.php
+++ b/classes/local_contact.php
@@ -100,11 +100,6 @@ class local_contact {
 
         // START: Spambot detection.
 
-        // File attachments not supported.
-        if (!$this->isspambot && $this->isspambot = !empty($_FILES)) {
-            $this->errmsg = 'File attachments not supported.';
-        }
-
         // Validate submit button.
         if (!$this->isspambot && $this->isspambot = !isset($_POST['submit'])) {
             $this->errmsg = 'Missing submit button.';
@@ -325,6 +320,20 @@ class local_contact {
             }
         }
 
+        $attachname = '';
+        $attachpath = '';
+        // Take the first file as an attachment.
+        foreach ($_FILES as $value) {
+            $attachname = $value['name'];
+            $path = $CFG->tempdir . '/local_contact/';
+            if (!is_dir($path)) {
+                mkdir($path); // Create temp directory if it does not exist.
+            }
+            $attachpath = tempnam($path, 'attachment_');
+            move_uploaded_file($value['tmp_name'], $attachpath);
+            break;
+        }
+
         // Sanitize user agent and referer.
         $httpuseragent = format_text($_SERVER['HTTP_USER_AGENT'], FORMAT_PLAIN, array('trusted' => false));
         $httpreferer = format_text($_SERVER['HTTP_REFERER'], FORMAT_PLAIN, array('trusted' => false));
@@ -354,10 +363,10 @@ class local_contact {
 
         // Send email message to recipient and set replyto to the sender's email address and name.
         if (empty(get_config('local_contact', 'noreplyto'))) { // Not checked.
-            $status = email_to_user($to, $from, $subject, html_to_text($htmlmessage), $htmlmessage, '', '', true,
+            $status = email_to_user($to, $from, $subject, html_to_text($htmlmessage), $htmlmessage, $attachpath, $attachname, true,
                     $from->email, $from->firstname);
         } else { // Checked.
-            $status = email_to_user($to, $from, $subject, html_to_text($htmlmessage), $htmlmessage, '', '', true);
+            $status = email_to_user($to, $from, $subject, html_to_text($htmlmessage), $htmlmessage, $attachpath, $attachname, true);
         }
         $CFG->noreplyaddress = $noreplyaddress;
 


### PR DESCRIPTION
This adds the ability to have an attachment field on the contact form, this should resolve #46 
It requires the form sets enctype to `mutlipart/form-data`, the file input can have any name.

It is limited to only one attachment/file per form as the Moodle function `email_to_user` used  by the plugin only accepts one attachment.

Example form:
```html
<form action="/local/contact/index.php" method="post" enctype="multipart/form-data" class="contact-us">
    <fieldset>
        <label for="name" id="namelabel">Your name <strong class="required">(required)</strong></label><br>
        <input id="name" name="name" type="text" size="57" maxlength="45" pattern="[A-zÀ-ž]([A-zÀ-ž\s]){2,}"
                title="Minimum 3 letters/spaces." required="required" value=""><br>
        <label for="email" id="emaillabel">Email address <strong class="required">(required)</strong></label><br>
        <input id="email" name="email" type="email" size="57" maxlength="60" required="required" value=""><br>
        <label for="subject" id="subjectlabel">Subject <strong class="required">(required)</strong></label><br>
        <input id="subject" name="subject" type="text" size="57" maxlength="80" minlength="5"
                title="Minimum 5 characters." required="required"><br>
        <label for="message" id="messagelabel">Message <strong class="required">(required)</strong></label><br>
        <textarea id="message" name="message" rows="5" cols="58" minlength="5"
                title="Minimum 5 characters." required="required"></textarea><br>
        <label for="attachment" id="attachmentlabel">Attachment</label><br>
        <input type="file" id="attachment" name="attachment">
        <input type="hidden" id="sesskey" name="sesskey" value="">
        <script>document.getElementById('sesskey').value = M.cfg.sesskey;</script>
    </fieldset>
    <div>
        <input type="submit" name="submit" id="submit" value="Send">
    </div>
</form>
```